### PR TITLE
Make `PusTelecommand` inherit from `AbstractSpacePacket`

### DIFF
--- a/spacepackets/ccsds/spacepacket.py
+++ b/spacepackets/ccsds/spacepacket.py
@@ -127,6 +127,10 @@ class AbstractSpacePacket(ABC):
     def seq_count(self) -> int:
         pass
 
+    @abstractmethod
+    def pack(self) -> bytearray:
+        pass
+
 
 class SpacePacketHeader(AbstractSpacePacket):
     """This class encapsulates the space packet header.

--- a/spacepackets/ecss/tc.py
+++ b/spacepackets/ecss/tc.py
@@ -17,6 +17,7 @@ from spacepackets.ccsds.spacepacket import (
     PacketType,
     SPACE_PACKET_HEADER_SIZE,
     SpacePacket,
+    AbstractSpacePacket,
     PacketId,
     PacketSeqCtrl,
     SequenceFlags,
@@ -104,7 +105,7 @@ class InvalidTcCrc16(Exception):
         self.tc = tc
 
 
-class PusTelecommand:
+class PusTelecommand(AbstractSpacePacket):
     """Class representation of a PUS telecommand. Can be converted to the raw byte representation
     but also unpacked from a raw byte stream. Only PUS C telecommands are supported.
 


### PR DESCRIPTION
`PusTelemetry` inherits from the `AbstractSpacePacket` class. For consistency, make `PusTelecommand` inherit from it too. It would allow for generic use grouping the two types of packets (e.g. SpaceWire packets which can contain a TC or TM).

Furthermore, the `pack` method was added to the `AbstractSpacePacket` as it is implemented by both TC and TM classes.