### PR TITLE
PDUs with CRC flag fail to round-trip through pack()/unpack()

### DIFF
--- a/spacepackets/cfdp/pdu/eof.py
+++ b/spacepackets/cfdp/pdu/eof.py
@@ -150,6 +150,8 @@ class EofPdu(AbstractFileDirectiveBase):
         current_idx, eof_pdu.file_size = eof_pdu.pdu_file_directive.parse_fss_field(
             raw_packet=data, current_idx=current_idx
         )
+        if eof_pdu.pdu_file_directive.pdu_conf.crc_flag == CrcFlag.WITH_CRC:
+            data = data[:-2]
         if len(data) > current_idx:
             eof_pdu.fault_location = EntityIdTlv.unpack(data=data[current_idx:])
         return eof_pdu

--- a/spacepackets/cfdp/pdu/file_data.py
+++ b/spacepackets/cfdp/pdu/file_data.py
@@ -255,6 +255,9 @@ class FileDataPdu(AbstractPduBase):
             data[current_idx : current_idx + struct_arg_tuple[1]],
         )[0]
         current_idx += struct_arg_tuple[1]
+
+        if file_data_packet.pdu_header.crc_flag == CrcFlag.WITH_CRC:
+            data = data[:-2]
         if current_idx < len(data):
             file_data_packet._params.file_data = data[current_idx:]
         return file_data_packet

--- a/spacepackets/cfdp/pdu/metadata.py
+++ b/spacepackets/cfdp/pdu/metadata.py
@@ -238,6 +238,8 @@ class MetadataPdu(AbstractFileDirectiveBase):
         current_idx += metadata_pdu._source_file_name_lv.packet_len
         metadata_pdu._dest_file_name_lv = CfdpLv.unpack(raw_bytes=data[current_idx:])
         current_idx += metadata_pdu._dest_file_name_lv.packet_len
+        if metadata_pdu.pdu_file_directive.pdu_conf.crc_flag == CrcFlag.WITH_CRC:
+            data = data[:-2]
         if current_idx < len(data):
             metadata_pdu._parse_options(raw_packet=data, start_idx=current_idx)
         return metadata_pdu

--- a/tests/cfdp/pdus/test_eof_pdu.py
+++ b/tests/cfdp/pdus/test_eof_pdu.py
@@ -63,6 +63,9 @@ class TestEofPdu(TestCase):
         self.assertEqual(eof.packet_len, expected_packet_len)
         eof_raw = eof.pack()
         self.assertEqual(len(eof_raw), expected_packet_len)
+        # verify we can round-trip pack/unpack
+        eof_unpacked = EofPdu.unpack(data=eof_raw)
+        self.assertEqual(eof_unpacked, eof)
 
     def test_from_factory(self):
         eof_pdu_raw = self.eof_pdu.pack()

--- a/tests/cfdp/pdus/test_file_data.py
+++ b/tests/cfdp/pdus/test_file_data.py
@@ -74,6 +74,19 @@ class TestFileDataPdu(TestCase):
         self.assertEqual(file_data_pdu_unpacked.offset, 0)
         self.assertEqual(file_data_pdu_unpacked.file_data, self.file_data_bytes)
 
+    def test_pack_unpack_w_crc(self):
+        pdu_conf = PduConfig.default()
+        pdu_conf.crc_flag = CrcFlag.WITH_CRC
+        fd_pdu = FileDataPdu(pdu_conf, FileDataParams(self.file_data_bytes, 0))
+        packed = fd_pdu.pack()
+        expected_bytes = bytearray([0x32, 0x00, 0x11, 0x00, 0x00, 0x00, 0x00])
+        expected_bytes.extend(bytes([0x00, 0x00, 0x00, 0x00]))
+        expected_bytes.extend(self.file_data_bytes)
+        expected_bytes.extend(bytes([0xF6, 0xEB]))  # CRC16
+        self.assertEqual(packed, expected_bytes)
+        unpacked = FileDataPdu.unpack(packed)
+        self.assertEqual(unpacked, fd_pdu)
+
     def test_with_seg_metadata(self):
         fd_params = FileDataParams(
             file_data=self.file_data_bytes,

--- a/tests/cfdp/pdus/test_metadata.py
+++ b/tests/cfdp/pdus/test_metadata.py
@@ -67,6 +67,9 @@ class TestMetadata(TestCase):
         self.assertEqual(metadata_pdu.packet_len, expected_len)
         metadata_raw = metadata_pdu.pack()
         self.assertEqual(len(metadata_raw), expected_len)
+        # verify a round-trip works w/ CRC set.
+        metadata_unpacked = MetadataPdu.unpack(metadata_raw)
+        self.assertEqual(metadata_pdu, metadata_unpacked)
 
     def test_metadata_pdu(self):
         self.assertEqual(self.option_0.packet_len, 13)


### PR DESCRIPTION
Added an illustrative test, and a proposed fix for the Metadata-pdu.