### PR TITLE
ci: add macOS to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary

Closes #138.

- Add `macos-latest` to the CI OS matrix — a one-line change to `.github/workflows/ci.yml`
- Add `Operating System :: MacOS` classifier to `pyproject.toml` to reflect the new platform support

No build issues expected: `fastcrc` ships pre-built ARM64 macOS wheels, so there's no native compilation step.