### PR TITLE
RFC - Restore `Subservice` export for compatibility

### DIFF
--- a/src/spacepackets/ecss/pus_17_test.py
+++ b/src/spacepackets/ecss/pus_17_test.py
@@ -16,6 +16,9 @@ class MessageSubtype(enum.IntEnum):
     TM_REPLY = 2
 
 
+Subservice = MessageSubtype
+
+
 class Service17Tm(AbstractPusTm):
     def __init__(
         self,

--- a/src/spacepackets/ecss/pus_3_hk.py
+++ b/src/spacepackets/ecss/pus_3_hk.py
@@ -21,3 +21,6 @@ class MessageSubtype(enum.IntEnum):
 
     TC_MODIFY_PARAMETER_REPORT_COLLECTION_INTERVAL = 31
     TC_MODIFY_DIAGNOSTICS_REPORT_COLLECTION_INTERVAL = 32
+
+
+Subservice = MessageSubtype

--- a/src/spacepackets/ecss/pus_5_event.py
+++ b/src/spacepackets/ecss/pus_5_event.py
@@ -8,3 +8,6 @@ class MessageSubtype(enum.IntEnum):
     TM_HIGH_SEVERITY_EVENT = 4
     TC_ENABLE_EVENT_REPORTING = 5
     TC_DISABLE_EVENT_REPORTING = 6
+
+
+Subservice = MessageSubtype

--- a/tests/ecss/test_message_subtype_compat.py
+++ b/tests/ecss/test_message_subtype_compat.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from spacepackets.ecss import pus_3_hk, pus_5_event, pus_17_test
+
+
+class TestMessageSubtypeCompat(TestCase):
+    def test_service_17_exports_legacy_subservice_enum_alias(self):
+        self.assertIs(pus_17_test.Subservice, pus_17_test.MessageSubtype)
+
+    def test_service_3_exports_legacy_subservice_enum_alias(self):
+        self.assertIs(pus_3_hk.Subservice, pus_3_hk.MessageSubtype)
+
+    def test_service_5_exports_legacy_subservice_enum_alias(self):
+        self.assertIs(pus_5_event.Subservice, pus_5_event.MessageSubtype)


### PR DESCRIPTION
I tried to update one of the consuming projects, https://github.com/robamu-org/tmtccmd, and run into test failures of the kind `ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_5_event'`

<details>
<summary>Full stacktrace</summary>


```
➜ uv pip install -e ".[test]" && uv run pytest
    Updated https://github.com/us-irs/py-spacepackets.git (abba1784
Resolved 24 packages in 1.99s
      Built tmtccmd @ file:///Users/gio/Developer/oss/space-and-ene
      Built spacepackets @ git+https://github.com/us-irs/py-spacepa
Prepared 2 packages in 719ms
Uninstalled 2 packages in 15ms
Installed 2 packages in 2ms
 - spacepackets==0.31.0
 + spacepackets==0.31.0 (from git+https://github.com/us-irs/py-spacepackets.git@abba178451e39974ad96d0a4478a554365a14e05)
 ~ tmtccmd==9.0.0 (from file:///Users/gio/Developer/oss/space-and-energy/tmtccmd)
    Updated https://github.com/us-irs/py-spacepackets.git (abba1784
===================== test session starts =====================
platform darwin -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/gio/Developer/oss/space-and-energy/tmtccmd
configfile: pyproject.toml
plugins: pyfakefs-5.10.2
collected 107 items / 7 errors

=========================== ERRORS ============================
________ ERROR collecting src/tmtccmd/pus/s17_test.py _________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/src/tmtccmd/pus/s17_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/s17_test.py:2: in <module>
    from .tc.s17_test import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s17_test.py:3: in <module>
    from spacepackets.ecss.pus_17_test import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_17_test' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_17_test.py)
_______ ERROR collecting src/tmtccmd/pus/tc/s17_test.py _______
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/src/tmtccmd/pus/tc/s17_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s17_test.py:3: in <module>
    from spacepackets.ecss.pus_17_test import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_17_test' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_17_test.py)
__________ ERROR collecting tests/com/test_dummy.py ___________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/tests/com/test_dummy.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/com/test_dummy.py:5: in <module>
    from tmtccmd.com.dummy import DummyInterface
src/tmtccmd/com/dummy.py:21: in <module>
    from tmtccmd.pus.s17_test import Subservice as Pus17Subservice
src/tmtccmd/pus/s17_test.py:2: in <module>
    from .tc.s17_test import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s17_test.py:3: in <module>
    from spacepackets.ecss.pus_17_test import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_17_test' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_17_test.py)
___________ ERROR collecting tests/test_backend.py ____________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/tests/test_backend.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_backend.py:8: in <module>
    from tmtccmd.com.dummy import DummyInterface
src/tmtccmd/com/dummy.py:21: in <module>
    from tmtccmd.pus.s17_test import Subservice as Pus17Subservice
src/tmtccmd/pus/s17_test.py:2: in <module>
    from .tc.s17_test import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s17_test.py:3: in <module>
    from spacepackets.ecss.pus_17_test import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_17_test' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_17_test.py)
___________ ERROR collecting tests/test_printer.py ____________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/tests/test_printer.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_printer.py:18: in <module>
    from tmtccmd.pus.s17_test import create_service_17_ping_command
src/tmtccmd/pus/s17_test.py:2: in <module>
    from .tc.s17_test import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s17_test.py:3: in <module>
    from spacepackets.ecss.pus_17_test import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_17_test' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_17_test.py)
_________ ERROR collecting tests/tm/test_srv3_fsfw.py _________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/tests/tm/test_srv3_fsfw.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/tm/test_srv3_fsfw.py:7: in <module>
    from tmtccmd.pus.s3_fsfw_hk import Subservice
src/tmtccmd/pus/s3_fsfw_hk.py:1: in <module>
    from .tc.s3_fsfw_hk import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tc/s3_fsfw_hk.py:6: in <module>
    from spacepackets.ecss.pus_3_hk import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_3_hk' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_3_hk.py)
___________ ERROR collecting tests/tm/test_srv5.py ____________
ImportError while importing test module '/Users/gio/Developer/oss/space-and-energy/tmtccmd/tests/tm/test_srv5.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/tm/test_srv5.py:4: in <module>
    from tmtccmd.pus.s5_fsfw_event import EventDefinition, Service5Tm, Subservice
src/tmtccmd/pus/s5_fsfw_event.py:4: in <module>
    from .tm.s5_fsfw_event import *  # noqa re-export
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/tmtccmd/pus/tm/s5_fsfw_event.py:11: in <module>
    from spacepackets.ecss.pus_5_event import Subservice
E   ImportError: cannot import name 'Subservice' from 'spacepackets.ecss.pus_5_event' (/Users/gio/Developer/oss/space-and-energy/tmtccmd/.venv/lib/python3.14/site-packages/spacepackets/ecss/pus_5_event.py)
=================== short test summary info ===================
ERROR src/tmtccmd/pus/s17_test.py
ERROR src/tmtccmd/pus/tc/s17_test.py
ERROR tests/com/test_dummy.py
ERROR tests/test_backend.py
ERROR tests/test_printer.py
ERROR tests/tm/test_srv3_fsfw.py
ERROR tests/tm/test_srv5.py
!!!!!!!!!!! Interrupted: 7 errors during collection !!!!!!!!!!!
====================== 7 errors in 0.39s ======================
```

</details>

The reason, as far as I understand, is that with #135 replacing `subservice` with `message_subtype`, the `Subservice` export has been removed.

This opens up an interesting question: **Should the PUS-C change be a breaking change or a deprecation?**

Given the library is not in a stable version yet, according to [SemVer](https://semver.org/), breaking changes are allowed. Still, I tried to implement #135 as a deprecation only. Evidently, I didn't do a enough of a good job.

_If_ deprecation is the way to move, then this PR restores support for `Subservice`. There's more work to do, though, because pointing to these changes still has test failures on the constructors.

<details>
<summary>Details</summary>

```
========================== FAILURES ===========================
___________________ TestDummy.test_dummy_if ___________________

self = <tests.com.test_dummy.TestDummy testMethod=test_dummy_if>

    def test_dummy_if(self):
        dummy_com_if = DummyInterface()
        self.assertFalse(dummy_com_if.is_open())
        dummy_com_if.open()
        self.assertTrue(dummy_com_if.is_open())
        self.assertFalse(dummy_com_if.initialized)
        dummy_com_if.initialize()
        self.assertTrue(dummy_com_if.initialized)
        self.assertEqual(dummy_com_if.packets_available(), 0)
>       dummy_com_if.send(PusTelecommand(apid=0x02, service=17, subservice=1).pack())

tests/com/test_dummy.py:18:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/tmtccmd/com/dummy.py:149: in send
    self.dummy_handler.insert_telecommand(data)
src/tmtccmd/com/dummy.py:35: in insert_telecommand
    self.generate_reply_package()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tmtccmd.com.dummy.DummyHandler object at 0x10be581a0>

    def generate_reply_package(self):
        """Generate a reply package. Currently, this only generates a reply for a ping
        telecommand."""
        assert self.last_tc is not None
        if self.last_tc.service == 17 and self.last_tc.subservice == 1:
            current_time_stamp = CdsShortTimestamp.now()
            tm_packer = Service1Tm(
                subservice=Pus1Subservice.TM_ACCEPTANCE_SUCCESS,
                apid=self.last_tc.apid,
                seq_count=self.current_ssc,
                verif_params=VerificationParams(
                    req_id=RequestId(self.last_tc.packet_id, self.last_tc.packet_seq_control)
                ),
                timestamp=current_time_stamp.pack(),
            )

            self.current_ssc += 1
            tm_packet_raw = tm_packer.pack()
            self.next_telemetry_package.append(tm_packet_raw)
            tm_packer = Service1Tm(
                subservice=Pus1Subservice.TM_START_SUCCESS,
                apid=self.last_tc.apid,
                seq_count=self.current_ssc,
                verif_params=VerificationParams(
                    req_id=RequestId(self.last_tc.packet_id, self.last_tc.packet_seq_control)
                ),
                timestamp=current_time_stamp.pack(),
            )
            tm_packet_raw = tm_packer.pack()
            self.next_telemetry_package.append(tm_packet_raw)
            self.current_ssc += 1

>           tm_packer = Service17Tm(
                subservice=Pus17Subservice.TM_REPLY,
                apid=self.last_tc.apid,
                timestamp=current_time_stamp.pack(),
            )
E           TypeError: Service17Tm.__init__() got an unexpected keyword argument 'subservice'

src/tmtccmd/com/dummy.py:69: TypeError
______________ TestTelemetry.test_generic_pus_c _______________

self = <tests.tm.test_srv17.TestTelemetry testMethod=test_generic_pus_c>

    def setUp(self) -> None:
        self.apid = 0xEF
>       self.pus_17_telemetry = Service17Tm(
            apid=self.apid,
            subservice=1,
            ssc=36,
            timestamp=CdsShortTimestamp.now().pack(),
        )
E       TypeError: Service17Tm.__init__() got an unexpected keyword argument 'subservice'

tests/tm/test_srv17.py:11: TypeError
```

</details>

I'm not sure what the best way forward is in relation to the library design and its consumers. Keen to help either way, be that via a deprecation with support for `subservice` or a breaking change that keeps only `message_subtype` and require source changes in the consumers.